### PR TITLE
Add MIT iQuHack Challenge repository as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs/notebooks/mit_iquhack"]
+	path = docs/notebooks/mit_iquhack
+	url = https://github.com/iQuHACK/2022_qutech_challenge

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The source for the Quantum Inspire examples can be found at Github. For the defa
 ```
 git clone https://github.com/QuTech-Delft/quantum-inspire-examples
 cd quantum-inspire-examples
+git submodule update --init
 pip install .
 ```
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -30,6 +30,7 @@ The source for the Quantum Inspire examples can be found at Github. For the defa
 
     git clone https://github.com/QuTech-Delft/quantum-inspire-examples
     cd quantum-inspire-examples
+    git submodule update --init
     pip install .
 
 


### PR DESCRIPTION
This pull request is meant to add the repository storing the MIT iQuHack 2022 QuTech Challenge documents as a submodule of this repository. The decision to proceed in this way was taken to ensure the organizing team at MIT could trace back any forks of the repository to the iQuHack 2022 event.